### PR TITLE
Render repos with no commits; Fix commit messages

### DIFF
--- a/src/git_mappers.js
+++ b/src/git_mappers.js
@@ -37,12 +37,12 @@ function mapLineToObject(line) {
 }
 
 function mapRawCommit(rawCommit) {
-    // todo handle double newlines in commit message
-    const [meta, msg] = rawCommit.split("\n\n");
+    // ignore longer commit messages
+    const [meta, msg, ..._rest] = rawCommit.split("\n\n");
     const dependencies = compact(map(compact(splitLines(meta)), mapLineToCommit));
     return {
         ...combineByKeys(dependencies, "type", "hash"),
-        // msg: msg.trim(),
+        msg: msg.trim(),
     };
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -97,9 +97,9 @@ async function main() {
     const rawHEAD = fs.readFileSync(`${gitDir}/HEAD`).toString();
     const HEAD = rawHEAD.startsWith("ref:") ? splitByWhitespace(rawHEAD)[1] : rawHEAD;
 
-    // there may be no tags at all
+    // there may be no tags at all and a repo with no commits will have a floating main branch
     const tagData = map(compact(splitLines(await showTags().catch(() => ""))), mapLineToRef);
-    const headData = map(compact(splitLines(await showHeads())), mapLineToRef);
+    const headData = map(compact(splitLines(await showHeads().catch(() => ""))), mapLineToRef);
 
     /**
      * TODO think more about what the command line options do,


### PR DESCRIPTION
I figure that showing just the first line of a commit message is better than 'undefined' in every commit oval. It works well enough for github, and a dot diagram is a more limited media than an HTML5 webpage.

Also wanted to allow the tool to draw repos with no commits, as this tool is best suited for rendering small repos at early stages.