### PR TITLE
Fix signed commit parsing

### DIFF
--- a/src/string_utils.js
+++ b/src/string_utils.js
@@ -3,6 +3,6 @@ const angles = exp => `<${exp}>`;
 const quote = exp => `"${exp}"`;
 const head8 = str => str.substr(0, 8);
 const splitLines = string => string.split("\n");
-const splitByWhitespace = string => string.match(/\S+/g);
+const splitByWhitespace = string => string.split(/\s+/);
 
 module.exports = { brackets, angles, quote, head8, splitLines, splitByWhitespace };


### PR DESCRIPTION
`git cat-file -p` prints a line with exactly one space in the gpgsig field:

```
tree 4e106a40b2a94ad05c07f468b6a42c70c8dfbc92
author Wesley Hershberger <wesley.hershberger@gmail.com> 1735948225 -0600
committer Wesley Hershberger <wesley.hershberger@gmail.com> 1735948225 -0600
gpgsig -----BEGIN PGP SIGNATURE-----
 
 iQIzBAABCgAdFiEEfR/udCi18IiNKEx/6wQXSW18s8oFAmd4d9QACgkQ6wQXSW18
 s8oeeA//R5LlNEahrmaFe2m4RT5yajue8obhlQa9zToyzDSy8Y7yrSVAX7KUB/AA
 d6uc6QVIH4nY/1O7clXvHQNlUk+2QZK0lTVycmmH6yuVnbxBpaEtGBrM7uGr+Id4
 YP86SXMdvmys+3CxIcfnAXicBwuhYlk5PPvDGxMjTPjnycUfWciRMUnQt0hdPnU5
 0ZiAA08NQu8pfsw6UDbp4Ih/OGuyUHHfphL60dTIJsgr8iJ4a0iiTpfxY1dkIxrB
 zc3PCKTv3xVqTfT/pNSczOOjVWaDBf/eUBgv5rM/Cmh227rZYa9wgB0/y76EphKy
 QAzqT7U76/VadAPim4oCwk5xovqQ4TrBw+3bVaEW9dowCV4oIzjtI8ryUS8G9rsX
 +XUKTwgteVtcPYHlx+pHlfZNRC/yia7nqFGzLxjWqmh1NUvfapDfkGCB2Op4VMFY
 bEzJoJG2H1mQFftbgYwWXNPwKsRfnbgiquk08tc05sy879FDnvsPBB/IYWS6bzch
 5y7FeBtRmhVZssdyT7l4QE4EFaQ/ZLsc3iQMLFC9fopkRmTBlg5Ltn4xQ4B9cmZ4
 9LhlL2n3iNcGoDfCky2GEzuK9El1vGXhTskmMh6FL6kXAwVMPbdMJRclTVWY1lRs
 Awg5UiOvKgAFG39KqYz9Bv27WLKfkZPv4MrJlVaDsYfEZJNRdAI=
 =qmww
 -----END PGP SIGNATURE-----

Initial commit
```

`string.match` then returns null for that line, causing an exception during pattern matching.