### PR TITLE
Support non-tag/head refs

### DIFF
--- a/src/git_mappers.js
+++ b/src/git_mappers.js
@@ -161,6 +161,13 @@ const mapTagToStatements = createRefMapper({
     margin: 0.2,
 });
 
+const mapRefsToStatements = createRefMapper({
+    refBasePath: "refs/",
+    shape: "cds",
+    fillColor: "orange",
+    margin: 0.1,
+});
+
 module.exports = {
     mapLineToObject,
     mapLineToRef,
@@ -170,6 +177,7 @@ module.exports = {
     mapAnnotatedTag,
     mapHeadToStatements,
     mapTagToStatements,
+    mapRefsToStatements,
     mapTreeToStatements,
     mapCommitToStatements,
     mapBlobToStatement,

--- a/src/index.js
+++ b/src/index.js
@@ -94,14 +94,15 @@ async function main() {
     );
 
     // git HEAD could be detached, referring directly to a commit, not another ref
-    const rawHEAD = fs.readFileSync(`${gitDir}/HEAD`).toString();
+    const rawHEAD = fs.readFileSync(`${gitDir}/HEAD`).toString().trim();
     const HEAD = rawHEAD.startsWith("ref:") ? splitByWhitespace(rawHEAD)[1] : rawHEAD;
 
     // perfectly alright to have no refs at all (empty repo)
     const refData = map(compact(splitLines(await showRefs().catch(() => ""))), mapLineToRef);
 
-    // Only draw HEAD if it points to a ref that exists
-    const validHead = some(refData, (ref) => HEAD === ref.name);
+    // Only draw HEAD if it points to a ref or commit that exists
+    const refsAndCommits = refData.concat(commitData);
+    const validHead = some(refsAndCommits, (obj) => HEAD === obj.name || HEAD === obj.hash);
 
     const tagData = filter(refData, (ref) => ref.name.includes("/tags/"));
     const headData = filter(refData, (ref) => ref.name.includes("/heads/"));


### PR DESCRIPTION
You can totally just create random references under `.git/refs`, this allows them to be rendered (in orange).

This also only draws `HEAD` when it points to a valid reference (rather than the previous behavior which left a weird floating `HEAD -> refs/heads/main`).

TODOs:
 - [ ] Correctly identify & draw virtual references (any ref can point to another ref, not just `HEAD`)
 - [x] Debug detached head state? (Unknown if this is a bug)
 - [ ] Other special references like `CHERRY_PICK_HEAD`

@gorhawk Just finished my second talk on git using this tool; kudos on this again, I've had fun working with it.